### PR TITLE
Rename WProgram.h to Arduino.h

### DIFF
--- a/morse.h
+++ b/morse.h
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 
 // Arduino language types
-#include "WProgram.h"
+#include "Arduino.h"
 
 #define WPM_DEFAULT	12.0
 // PARIS WPM measurement: 50; CODEX WPM measurement: 60 (Wikipedia:Morse_code)


### PR DESCRIPTION
They apparently renamed WProgram.h to Arduino.h as of Arduino IDE 1.0 (Released 2011.11.30)

Thanks for a great library!
