### PR TITLE
fix unsign int / int comparison in SpeakerMorseSender::setOff()

### DIFF
--- a/morse.cpp
+++ b/morse.cpp
@@ -105,12 +105,12 @@ void MorseSender::setup() { pinMode(pin, OUTPUT); }
 
 void MorseSender::setWPM(float wpm)
 {
-	setSpeed((morseTiming_t)(1000.0*60.0/(max(1.0, wpm)*DITS_PER_WORD)));
+	setSpeed((morseTiming_t)(1000.0*60.0/(max(1.0f, wpm)*DITS_PER_WORD)));
 }
 
 void MorseSender::setSpeed(morseTiming_t duration)
 {
-	DIT = max(1, duration);
+	DIT = max(duration, (morseTiming_t) 1);
 	DAH = 3*DIT;
 }
 

--- a/morse.h
+++ b/morse.h
@@ -28,12 +28,12 @@
 // PARIS WPM measurement: 50; CODEX WPM measurement: 60 (Wikipedia:Morse_code)
 #define DITS_PER_WORD	50
 // Pass to SpeakerMorseSender as carrierFrequency to suppress the carrier.
-#define CARRIER_FREQUENCY_NONE	-1
+#define CARRIER_FREQUENCY_NONE	0
 
 // Bitmasks are 1 for dah and 0 for dit, in left-to-right order;
 //	the sequence proper begins after the first 1 (a sentinel).
 //	Credit for this scheme to Mark VandeWettering K6HX ( brainwagon.org ).
-typedef int             morseTiming_t;
+typedef unsigned int             morseTiming_t;
 typedef unsigned char	morseBitmask_t; // see also MAX_TIMINGS
 #define MORSE_BITMASK_HIGH_BIT	B10000000
 


### PR DESCRIPTION
carrierFrequency defined in SpeakserMorseSender is unsigned int but CARRIER_FREQUENCY_NONE is defined as -1.  This is causing some logic error.  

Changing CARRIER_FREQUENCY_NONE to 0 also updated typedef of morseTiming_t.